### PR TITLE
Build OCI directories instead of docker tarballs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ TODO: Render documentation from starlark here
 
 ## Example
 ```bash
-$ buckle build //tests:image --out - | podman load
+$ buckle build //tests:image --show-simple-output | xargs podman load -i
 $ podman run -it --rm localhost:61978/image.tar:latest
 ```
 

--- a/oci/helpers/image.py
+++ b/oci/helpers/image.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
         registry_process = start_registry(args.crane, log_file)
         build_image(args.crane, args.base, args.tars, ' '.join(args.entrypoint) if args.entrypoint else None, ' '.join(args.cmd) if args.cmd else None, args.output, args.user, args.workdir, args.name, args.env)
     except subprocess.CalledProcessError as e:
-        eprint(f"Error: {e}", file=sys.stderr)
+        eprint(f"Error: {e}")
     finally:
         if registry_process:
             stop_registry(registry_process)

--- a/oci/helpers/pull.py
+++ b/oci/helpers/pull.py
@@ -6,7 +6,7 @@ def pull_image(crane_path, image, digest, platform, output):
     full_image = f"{image}@{digest}"
 
     # Construct and execute the crane pull command
-    command = [crane_path, 'pull', '--platform', platform, full_image, output]
+    command = [crane_path, 'pull', '--format=oci', '--platform', platform, full_image, output]
     subprocess.run(command, check=True)
 
 if __name__ == "__main__":

--- a/oci/image.bzl
+++ b/oci/image.bzl
@@ -7,7 +7,7 @@ def _oci_image_impl(ctx: AnalysisContext) -> list[Provider]:
     tars = ctx.attrs.tars
     tar_outputs = [tar[DefaultInfo].default_outputs for tar in tars]
 
-    image_name = "{}.tar".format(ctx.attrs.name)
+    image_name = ctx.attrs.name
 
     output = ctx.actions.declare_output(image_name)
 

--- a/oci/pull.bzl
+++ b/oci/pull.bzl
@@ -2,7 +2,7 @@ load("//oci:toolchain.bzl", "OciToolchainInfo")
 
 def _oci_pull_impl(ctx: AnalysisContext) -> list[Provider]:
     image = ctx.attrs.image
-    output = ctx.actions.declare_output("{}.tar".format(ctx.attrs.name))
+    output = ctx.actions.declare_output(ctx.attrs.name)
     platform = ctx.attrs.platforms[0]
 
     cmd = cmd_args(

--- a/oci/toolchain.bzl
+++ b/oci/toolchain.bzl
@@ -60,10 +60,7 @@ def _crane_binary_impl(ctx: AnalysisContext) -> list[Provider]:
     src = ctx.attrs.bin[DefaultInfo].default_outputs[0]
     ctx.actions.run(["cp", cmd_args(src, format = "{}/crane"), dst.as_output()], category = "cp_crane")
 
-    crane = cmd_args([dst])
-    crane.hidden()
-    crane.hidden(ctx.attrs.bin[DefaultInfo].default_outputs)
-    crane.hidden(ctx.attrs.bin[DefaultInfo].other_outputs)
+    crane = cmd_args([dst], hidden = ctx.attrs.bin[DefaultInfo].default_outputs + ctx.attrs.bin[DefaultInfo].other_outputs)
 
     return [
         ctx.attrs.bin[DefaultInfo],

--- a/tar/defs.bzl
+++ b/tar/defs.bzl
@@ -7,20 +7,20 @@ def _tar_file_impl(ctx: AnalysisContext) -> list[Provider]:
     tar_file = ctx.actions.declare_output(tar_output_name)
     srcs = ctx.attrs.srcs
 
-    srcs_file_cmd = cmd_args()
-    for src in srcs:
-        srcs_file_cmd.add(src)
+    # newline-separated list of source files
+    srcs_file_path = ctx.actions.write("srcs.txt", cmd_args(srcs))
 
-    srcs_file_path = ctx.actions.write("srcs.txt", srcs_file_cmd)
-
-    cmd = cmd_args(ctx.attrs._tar_toolchain[TarToolchainInfo].tar[RunInfo])
-    cmd.add("--compress")
-    cmd.add("true" if ctx.attrs.compress else "false")
-    cmd.add("--file_path")
-    cmd.add(srcs_file_path)
-    cmd.add("--filename")
-    cmd.add(tar_file.as_output())
-    cmd.hidden(srcs)
+    # this is not GNU tar. don't look these flags up in the manual.
+    cmd = cmd_args(
+        ctx.attrs._tar_toolchain[TarToolchainInfo].tar[RunInfo],
+        "--compress",
+        "true" if ctx.attrs.compress else "false",
+        "--file_path",
+        srcs_file_path,
+        "--filename",
+        tar_file.as_output(),
+        hidden = srcs,
+    )
 
     ctx.actions.run(cmd, category = "tar")
 


### PR DESCRIPTION
Fixes #5 , fixes a failure to to an `eprint` call, and also uses the newer version of Buck's `cmd_args` with kwargs instead of methods.

I'm not actually on a linux machine right now. I believe the updated readme example will go, but don't know how podman will name the loaded image so you can run it on the second line.

You can definitely do this:

```sh
buck2 build //tests:image --show-simple-output \
    | xargs -I{} skopeo copy oci:{} containers-storage:oci-rules-test
```