### PR TITLE
Fix env vars, empty tars, cmd splitting, and workaround a crane bug

### DIFF
--- a/examples/rust/BUCK
+++ b/examples/rust/BUCK
@@ -5,11 +5,12 @@ rust_binary(
     name = "rust-app",
     srcs = ["src/main.rs"],
     crate_root = "src/main.rs",
+    link_style = "static",
 )
 
 tar_file(
   name = "app",
-  srcs = [":rust-app[static]"],
+  srcs = [":rust-app"],
   out = "app.tar",
 )
 

--- a/oci/helpers/image.py
+++ b/oci/helpers/image.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     parser.add_argument("--crane", required=True, help="Path to the crane binary")
     parser.add_argument("--base", required=True, help="Base OCI image")
     parser.add_argument("--tars", nargs='+', required=True, help="Paths to tar files representing layers")
-    parser.add_argument("--env", nargs='+', required=False, help="Environment variables")
+    parser.add_argument("--env", action="append", required=False, help="Environment variables")
     parser.add_argument("--entrypoint", nargs='+', help="Entrypoint for the OCI image")
     parser.add_argument("--cmd", nargs='+', help="Command for the OCI image")
     parser.add_argument("--output", required=True, help="Path to the output OCI image directory")

--- a/oci/helpers/image.py
+++ b/oci/helpers/image.py
@@ -72,8 +72,8 @@ if __name__ == "__main__":
     parser.add_argument("--base", required=True, help="Base OCI image")
     parser.add_argument("--tars", nargs='+', required=True, help="Paths to tar files representing layers")
     parser.add_argument("--env", action="append", required=False, help="Environment variables")
-    parser.add_argument("--entrypoint", nargs='+', help="Entrypoint for the OCI image")
-    parser.add_argument("--cmd", nargs='+', help="Command for the OCI image")
+    parser.add_argument("--entrypoint", help="Entrypoint for the OCI image")
+    parser.add_argument("--cmd", help="Command for the OCI image")
     parser.add_argument("--output", required=True, help="Path to the output OCI image directory")
     parser.add_argument("--name", required=True, help="Name of the OCI image")
     parser.add_argument("--user", help="User")
@@ -85,7 +85,7 @@ if __name__ == "__main__":
 
     try:
         registry_process = start_registry(args.crane, log_file)
-        build_image(args.crane, args.base, args.tars, ' '.join(args.entrypoint) if args.entrypoint else None, ' '.join(args.cmd) if args.cmd else None, args.output, args.user, args.workdir, args.name, args.env)
+        build_image(args.crane, args.base, args.tars, args.entrypoint, args.cmd, args.output, args.user, args.workdir, args.name, args.env)
     except subprocess.CalledProcessError as e:
         eprint(f"Error: {e}")
     finally:

--- a/oci/helpers/image.py
+++ b/oci/helpers/image.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Build OCI image using Crane")
     parser.add_argument("--crane", required=True, help="Path to the crane binary")
     parser.add_argument("--base", required=True, help="Base OCI image")
-    parser.add_argument("--tars", nargs='+', required=True, help="Paths to tar files representing layers")
+    parser.add_argument("--tars", nargs='+', required=False, help="Paths to tar files representing layers", default=[])
     parser.add_argument("--env", action="append", required=False, help="Environment variables")
     parser.add_argument("--entrypoint", help="Entrypoint for the OCI image")
     parser.add_argument("--cmd", help="Command for the OCI image")

--- a/oci/helpers/image.py
+++ b/oci/helpers/image.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import json
 import tempfile
+import shutil
 
 REGISTRY_PORT = 61978
 
@@ -108,4 +109,6 @@ if __name__ == "__main__":
     finally:
         if registry_process:
             stop_registry(registry_process)
-            eprint(log_file.read())
+            log_file.seek(0)
+            shutil.copyfileobj(log_file, sys.stderr.buffer)
+        log_file.close()

--- a/oci/image.bzl
+++ b/oci/image.bzl
@@ -37,7 +37,7 @@ def _oci_image_impl(ctx: AnalysisContext) -> list[Provider]:
     if cmd:
       command.add(["--cmd", " ".join(cmd)])
     for k, v in ctx.attrs.env.items():
-      command.add(["--env", f"{k}={v}"])
+      command.add(["--env", "{}={}".format(k, v)])
     command.add([ "--name", image_name])
 
     ctx.actions.run(command, category = "oci")

--- a/oci/image.bzl
+++ b/oci/image.bzl
@@ -28,13 +28,13 @@ def _oci_image_impl(ctx: AnalysisContext) -> list[Provider]:
     user = ctx.attrs.user
     cmd = ctx.attrs.cmd
 
-    if entrypoint:
+    if entrypoint != None:
       command.add(["--entrypoint", ",".join(entrypoint)])
-    if workdir:
+    if workdir != None:
       command.add(["--workdir", workdir])
-    if user:
+    if user != None:
       command.add(["--user", workdir])
-    if cmd:
+    if cmd != None:
       command.add(["--cmd", ",".join(cmd)])
     for k, v in ctx.attrs.env.items():
       command.add(["--env", "{}={}".format(k, v)])
@@ -42,12 +42,12 @@ def _oci_image_impl(ctx: AnalysisContext) -> list[Provider]:
 
     ctx.actions.run(command, category = "oci")
 
-    return [DefaultInfo(default_output = output)]
+    return [ DefaultInfo(default_output = output) ]
 
 oci_image = rule(
     impl = _oci_image_impl,
     attrs = {
-        "base": attrs.dep(),
+        "base": attrs.dep(providers = [DefaultInfo]),
         "workdir": attrs.option(attrs.string(), default = None),
         "user": attrs.option(attrs.string(), default = None),
         "tars": attrs.list(attrs.dep()),

--- a/oci/image.bzl
+++ b/oci/image.bzl
@@ -19,8 +19,7 @@ def _oci_image_impl(ctx: AnalysisContext) -> list[Provider]:
         output.as_output(),
         "--base",
         base,
-        "--tars",
-        tar_outputs,
+        cmd_args("--tars", tar_outputs) if tar_outputs else cmd_args(),
     )
 
     entrypoint = ctx.attrs.entrypoint
@@ -50,7 +49,7 @@ oci_image = rule(
         "base": attrs.dep(providers = [DefaultInfo]),
         "workdir": attrs.option(attrs.string(), default = None),
         "user": attrs.option(attrs.string(), default = None),
-        "tars": attrs.list(attrs.dep()),
+        "tars": attrs.list(attrs.dep(), default = []),
         "env": attrs.dict(key=attrs.string(), value=attrs.string(), default = {}),
         "cmd": attrs.option(attrs.list(attrs.string()), default = None),
         "entrypoint": attrs.option(attrs.list(attrs.string()), default = None),

--- a/oci/image.bzl
+++ b/oci/image.bzl
@@ -35,7 +35,7 @@ def _oci_image_impl(ctx: AnalysisContext) -> list[Provider]:
     if user:
       command.add(["--user", workdir])
     if cmd:
-      command.add(["--cmd", " ".join(cmd)])
+      command.add(["--cmd", ",".join(cmd)])
     for k, v in ctx.attrs.env.items():
       command.add(["--env", "{}={}".format(k, v)])
     command.add([ "--name", image_name])


### PR DESCRIPTION
Basically fixes everything I've found

- Starlark does not have f-strings
- Previously you could not add multiple env vars, only one would get written
- Example runs on more recent buck preludes
- Fixes commands getting concatenated with spaces, join them with commas instead so crane can split them back up. **This is a breaking change -- entrypoints like `bash -c` won't work anymore as they'll only see the first arg now, but they should never have worked.**
- Fixes #3
- Workaround for https://github.com/google/go-containerregistry/issues/2041 so you can set an entrypoint without manually inspecting the base image & copy-pasting its cmd