### PR TITLE
Remove outdated commit hash from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add this repo as an external cell in your projects `.buckconfig`
 
 [external_cell_oci]
   git_origin = https://github.com/benbrittain/oci-rules.git
-  commit_hash = 7cda0ad213b2108f50beb756697f3c5435ad2c56
+  commit_hash = <set this to latest main branch commit hash>
 ```
 
 ### Configuring the toolchain


### PR DESCRIPTION
The version of oci-rules on this hash no longer works with latest buck2, bumping to use latest hash worked.